### PR TITLE
FIX Do not prevent the default link behaviour, and remove the product ID from data attributes

### DIFF
--- a/code/ChecIOShortcode.php
+++ b/code/ChecIOShortcode.php
@@ -14,10 +14,8 @@ class ChecIOShortcode extends Object
     {
         if (isset($arguments['data-chec-product-id'])) {
             $id = Convert::raw2att($arguments['data-chec-product-id']);
+            unset($arguments['data-chec-product-id']);
             $siteURL = self::config()->get('third-party-url');
-
-            // Add an onclick attribute to prevent following the re-written link anchor.
-            $arguments['onclick'] = 'event.preventDefault ? event.preventDefault() : event.returnValue = false;';
 
             $link = "<a href=\"$siteURL/{$id}\"";
             // Add all arguments as-is as we could potentially be receiving css class styles

--- a/tests/ChecIOShortcodeTest.php
+++ b/tests/ChecIOShortcodeTest.php
@@ -23,8 +23,7 @@ class ChecIOShortcodeTest extends FunctionalTest
         $text = $this->page->Content;
         $parsed = ShortcodeParser::get_active()->parse($text);
         $this->assertContains(
-            '<a href="https://checkout.chec.io/1" data-chec-product-id="1" '.
-                    'onclick="event.preventDefault ? event.preventDefault() : event.returnValue = false;">Buy Now</a>',
+            '<a href="https://checkout.chec.io/1">Buy Now</a>',
             $parsed
         );
     }


### PR DESCRIPTION
The inline "onclick" handler will stop the link working on mobile, which doesn't display a popup.

I can't find examples of using the data attribute inline on either chec.io or a few sites using it that I've checked. A bunch of data attributes (not this one) are added by the chec.io javascript lib, however.