### PR TITLE
NEW Allow Javascript Requirements to be skipped if set to a falsy value

### DIFF
--- a/code/ChecIOExtension.php
+++ b/code/ChecIOExtension.php
@@ -7,7 +7,9 @@ class ChecIOExtension extends SiteTreeExtension
      */
     public function contentcontrollerInit()
     {
-        Requirements::javascript(ChecIOShortcode::config()->get('third-party-js'));
+        if ($jsPath = ChecIOShortcode::config()->get('third-party-js')) {
+            Requirements::javascript($jsPath);
+        }
     }
 
     /**
@@ -18,9 +20,9 @@ class ChecIOExtension extends SiteTreeExtension
      */
     public function getChecIOJs()
     {
-        return sprintf(
-            '<script type="text/javascript" src="%s"></script>',
-            ChecIOShortcode::config()->get('third-party-js')
-        );
+        if ($jsPath = ChecIOShortcode::config()->get('third-party-js')) {
+            return sprintf('<script type="text/javascript" src="%s"></script>', $jsPath);
+        }
+        return '';
     }
 }

--- a/tests/ChecIOExtensionTest.php
+++ b/tests/ChecIOExtensionTest.php
@@ -24,4 +24,14 @@ class ChecIOExtensionTest extends SapphireTest
         $this->assertNotNull($result);
         $this->assertContains('<script type="text/javascript', $result);
     }
+
+    /**
+     * Allow the JS to be disabled if desired
+     */
+    public function testGetChecIOJsIgnoresIfFalsy()
+    {
+        Config::inst()->update('ChecIOShortcode', 'third-party-js', '');
+        $result = $this->page->getChecIOJs();
+        $this->assertNotContains('<script type="text/javascript', $result);
+    }
 }


### PR DESCRIPTION
In case a user wants to disable the chec.io Javascript requirements, for example if they've got a bundled version in their own user code.